### PR TITLE
Pull static files out of ~/data/

### DIFF
--- a/hellodjango/settings.py
+++ b/hellodjango/settings.py
@@ -60,7 +60,7 @@ MEDIA_URL = '/media/'
 # Don't put anything in this directory yourself; store your static files
 # in apps' "static/" subdirectories and in STATICFILES_DIRS.
 # Example: "/home/media/media.lawrence.com/static/"
-STATIC_ROOT = '/home/dotcloud/data/static/'
+STATIC_ROOT = '/home/dotcloud/volatile/static/'
 
 # URL prefix for static files.
 # Example: "http://media.lawrence.com/static/"

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,3 +1,3 @@
 location /media/ { root /home/dotcloud/data ; }
-location /static/ { root /home/dotcloud/data ; }
+location /static/ { root /home/dotcloud/volatile ; }
 

--- a/postinstall
+++ b/postinstall
@@ -1,5 +1,5 @@
 #!/bin/sh
 python hellodjango/manage.py syncdb --noinput
 python mkadmin.py
-mkdir -p /home/dotcloud/data/media /home/dotcloud/data/static
+mkdir -p /home/dotcloud/data/media /home/dotcloud/volatile/static
 python hellodjango/manage.py collectstatic --noinput


### PR DESCRIPTION
With the new "Granite" builder, DotCloud applications are built in the
background while your production application is still running. When the
build is finished the old service is stopped and its "~/data" directory
is migrated to the new service.

This change in the way applications are built means that the "~/data"
directory is only accessible during the initial push of an application.
In subsequent pushes the "~/data" directory is migrated when the build
is over which means that the build can no longer modify the "~/data"
directory.

This commit simply changes the path where static files are generated
(STATIC_ROOT) to the "~/volatile/static" directory.
